### PR TITLE
fix(Workspace): replace mkDir by ensureDir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos-core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "types": "out/index.d.ts",
   "main": "./out/index.js",

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,6 +1,5 @@
 import {
   mkdir,
-  mkdirSync,
   existsSync,
   PathLike,
   createWriteStream,
@@ -68,7 +67,7 @@ export class Workspace implements WorkspaceInterface {
     Preconditions.notNull(directory);
     this.directory = directory;
 
-    !existsSync(this.directory) && mkdirSync(this.directory);
+    !existsSync(this.directory) && ensureDirSync(this.directory.toString());
   }
 
   public getDirectory(): PathLike {


### PR DESCRIPTION
Using `ensureDirSync` from fs-extra to correctly make a directory and sub-directory. Since `mkdirSync` only executes if the parent directory is available