### PR TITLE
[fix] Resolve libraries for older version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kratos-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "types": "out/index.d.ts",
   "main": "./out/index.js",


### PR DESCRIPTION
Some older versions such as 1.12.2 cannot be started and cause error
```
(node:82698) UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of undefined (reading 'name')
    at VersionPackageManager.buildLibrariesMap
```
# Changes
- Remove library map, and use normal iterate to determine which library are used for